### PR TITLE
perf: use a set for extracted tag IDs

### DIFF
--- a/tests/test_base_clustering.py
+++ b/tests/test_base_clustering.py
@@ -74,7 +74,7 @@ class TestBaseClustering(unittest.TestCase):
         self.assertTrue(isinstance(tree_object, ClusterTreeObject))
         dict_collapsible_tree = tree_object.to_dict()
         self.assertTrue(dict_collapsible_tree, dict)
-        data_ids = self.__extract_tag_id(dict_collapsible_tree["children"], [])
+        data_ids = set(self.__extract_tag_id(dict_collapsible_tree["children"], []))
         for i in range(0, 100):
             self.assertTrue(i in data_ids)
         # test generating html file


### PR DESCRIPTION
This PR converts the extracted tag IDs to a set.

The IDs are used for membership checks, so order is not relevant. Using a set also removes duplicate IDs and reduces the average complexity of each lookup from O(n) to O(1).

The issue was identified during an ongoing research project.